### PR TITLE
Add support of module.noParse configuration for webpack

### DIFF
--- a/config.js
+++ b/config.js
@@ -154,6 +154,16 @@ class Config {
             pack.plugins.push(new webpack.ProvidePlugin(pack.global));
         }
 
+        if (pack.module && pack.module.noParse) {
+            pack.module.noParse = pack.module.noParse.map((value) => {
+                if (value.pattern) {
+                    return new RegExp(value.pattern);
+                } else {
+                    return value;
+                }
+            });
+        }
+
         conf.webpack = pack;
 
         return conf;

--- a/utils.js
+++ b/utils.js
@@ -195,7 +195,8 @@ class Utils {
                 resolve: conf.resolve,
                 output: {
                     publicPath: conf.publicPath
-                }
+                },
+                module: Object.assign({}, {loaders: []}, conf.module)
             }
         }
 


### PR DESCRIPTION
Currently setting module.noParse in kil section of package.json is not taking into consideration. Also this setting needs to support regular expression.